### PR TITLE
Handle EAI_NODATA in _check_hostname

### DIFF
--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -408,7 +408,7 @@ def _check_hostname(hostname: str) -> int:
         try:
             socket.getaddrinfo(hostname, None, family=socket.AF_INET)
         except socket.gaierror as e:
-            if e.errno != socket.EAI_NONAME:
+            if e.errno != socket.EAI_NONAME and e.errno != socket.EAI_NODATA:
                 # we got some sort of other socket error, so it's unclear if the host exists or not
                 return HOSTNAME_STATUS_UNKNOWN
 


### PR DESCRIPTION
Same as https://github.com/hauntsaninja/boostedblob/pull/26: On Ubuntu 24.04, looking up an unresolveable `<something>.blob.core.windows.net` returns `EAI_NODATA`, not `EAI_NONAME`.